### PR TITLE
Finalize Auctions and Add Contract State Queries

### DIFF
--- a/contracts/StackedTalents.clar
+++ b/contracts/StackedTalents.clar
@@ -161,3 +161,70 @@
         })))
     )
 )
+
+(define-public (complete-auction (auction-id uint))
+    (let 
+        (
+            (auction (unwrap! (map-get? auctions auction-id) ERR-NOT-FOUND))
+            (talent-data (unwrap! (map-get? talents tx-sender) ERR-NOT-FOUND))
+        )
+        ;; State checks
+        (asserts! (check-auction-active auction-id) ERR-AUCTION-NOT-ACTIVE)
+        (asserts! (>= stacks-block-height (get end-height auction)) ERR-AUCTION-NOT-ENDED)
+        (asserts! (is-eq (get talent auction) tx-sender) ERR-NOT-AUTHORIZED)
+
+        ;; Check if there was a bid
+        (asserts! (is-some (get highest-bidder auction)) ERR-INVALID-STATE)
+
+        ;; Transfer payment to talent
+        (try! (as-contract (stx-transfer? 
+            (get highest-bid auction)
+            tx-sender 
+            (get talent auction)
+        )))
+
+        ;; Update talent stats
+        (map-set talents tx-sender (merge talent-data {
+            total-earnings: (+ (get total-earnings talent-data) (get highest-bid auction)),
+            auctions-completed: (+ (get auctions-completed talent-data) u1)
+        }))
+
+        ;; Update global stats
+        (var-set total-auctions-completed (+ (var-get total-auctions-completed) u1))
+
+        (ok (map-set auctions auction-id (merge auction {
+            status: "completed"
+        })))
+    )
+)
+
+;; Read-only Functions
+(define-read-only (get-auction (auction-id uint))
+    (map-get? auctions auction-id)
+)
+
+(define-read-only (get-talent-info (address principal))
+    (map-get? talents address)
+)
+
+(define-read-only (get-contract-stats)
+    {
+        total-auctions: (var-get total-auctions-completed),
+        total-fees: (var-get total-fees-collected)
+    }
+)
+
+(define-read-only (is-registered (address principal))
+    (is-some (map-get? talents address))
+)
+
+(define-read-only (can-complete-auction (auction-id uint))
+    (match (map-get? auctions auction-id)
+        auction (and 
+            (is-eq (get status auction) "active")
+            (>= stacks-block-height (get end-height auction))
+            (is-some (get highest-bidder auction))
+        )
+        false
+    )
+)


### PR DESCRIPTION

###  Updated Pull Request Description

**Title:** `Finalize Auctions and Add Contract State Queries`

#### Overview

This update completes the core functionality of the Talent Marketplace smart contract. Talents can now finalize auctions after they end, receive payments, and have their profiles updated accordingly. The PR also introduces several read-only functions to query auction and contract state without incurring gas fees.

---

#### 🔧 Key Additions

##### ✅ `complete-auction`

Enables a registered talent to finalize their auction when:

* The auction is still active
* The end block height has passed
* The auction has a valid bid
* The caller is the auction creator

Upon success:

* Transfers the highest bid to the talent
* Updates their `total-earnings` and `auctions-completed`
* Updates `total-auctions-completed` for analytics
* Marks auction as `"completed"`

Includes all error handling using defined constants (`ERR-*`) and `unwrap!`, `asserts!`, and `try!`.

---

#### 🧠 New Read-Only Functions

| Function               | Description                                               |
| ---------------------- | --------------------------------------------------------- |
| `get-auction`          | Retrieves auction data by ID                              |
| `get-talent-info`      | Fetches a talent's profile using their principal          |
| `get-contract-stats`   | Returns total auctions completed and fees collected       |
| `is-registered`        | Checks if a principal is registered as a talent           |
| `can-complete-auction` | Returns `true` if an auction is eligible for finalization |

---